### PR TITLE
Fairly simple updates to bring oer-java inline with latest ORE API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openexchange</groupId>
 	<artifactId>oer-java</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>0.1.0</version>
 	<packaging>jar</packaging>
 	<name>oer-java</name>
 	<url>http://maven.apache.org</url>

--- a/src/main/java/org/openexchangerates/oerjava/OpenExchangeRates.java
+++ b/src/main/java/org/openexchangerates/oerjava/OpenExchangeRates.java
@@ -30,8 +30,8 @@ public abstract class OpenExchangeRates {
 	 * Generate and get a new Open Exchange Rates client
 	 * @return a Open Exchange Rates client
 	 */
-	public static OpenExchangeRates getClient() {
-		return new OpenExchangeRatesJsonClient();
+	public static OpenExchangeRates getClient(String apiKey) {
+		return new OpenExchangeRatesJsonClient(apiKey);
 	}
 
 	/**

--- a/src/main/java/org/openexchangerates/oerjava/OpenExchangeRatesJsonClient.java
+++ b/src/main/java/org/openexchangerates/oerjava/OpenExchangeRatesJsonClient.java
@@ -34,11 +34,21 @@ import org.openexchangerates.oerjava.exceptions.UnavailableExchangeRateException
  * @author Demétrio Menezes Neto
  */
 class OpenExchangeRatesJsonClient extends OpenExchangeRates {
-	private final static String OER_URL = "http://openexchangerates.org/";
-	private final static String LATEST = "latest.json";
-	private final static String HISTORICAL = "historical/%04d-%02d-%02d.json";
+	private final static String OER_URL = "http://openexchangerates.org/api/";
+	private String LATEST;
+	private String HISTORICAL;
 
 	private final static ObjectMapper mapper = new ObjectMapper();
+
+	/**
+	 * Constructor for a new OpenExchangeRatesJsonClient
+	 *
+	 * @param apiKey The API key to Open Exchange Rates
+	 */
+	public OpenExchangeRatesJsonClient(String apiKey) {
+		LATEST = "latest.json?app_id=" + apiKey;
+		HISTORICAL = "historical/%04d-%02d-%02d.json?app_id=" + apiKey;
+	}
 
 	/**
 	 * Downloads the exchanges rates from given json path

--- a/src/test/java/org/openexchange/oerjava/OERJavaTest.java
+++ b/src/test/java/org/openexchange/oerjava/OERJavaTest.java
@@ -53,7 +53,7 @@ public class OERJavaTest extends TestCase {
 	 * @throws UnavailableExchangeRateException
 	 */
 	public void testApp() throws UnavailableExchangeRateException {
-		OpenExchangeRates client = OpenExchangeRates.getClient();
+		OpenExchangeRates client = OpenExchangeRates.getClient("<<ADD IN YOUR KEY>>");
 
 		for (Map.Entry<Currency, BigDecimal> entry : client.getLatest()
 				.entrySet()) {
@@ -76,7 +76,7 @@ public class OERJavaTest extends TestCase {
 		assertTrue(client.getHistoricalCurrencyValue(Currency.USD, cal)
 				.compareTo(new BigDecimal(1)) == 0);
 
-		cal.set(Calendar.YEAR, 1990);
+		cal.set(Calendar.YEAR, 1999);
 		cal.set(Calendar.MONTH, Calendar.JANUARY);
 		cal.set(Calendar.DAY_OF_MONTH, 01);
 


### PR DESCRIPTION
Four things:
1. Changed test to use 1999 not 1990
2. Add API Key onto all reqs
3. Add `/api/...` into all paths
4. Version bump
